### PR TITLE
Added request limiter for warp server as security layer.

### DIFF
--- a/error.js
+++ b/error.js
@@ -26,7 +26,8 @@ WarpError.Code = {
     InvalidAPIKey: 109, // Invalid API Key
     ModelNotFound: 110,
     FunctionNotFound: 111,
-    QueueNotFound: 112
+    QueueNotFound: 112,
+    TooManyRequest: 429
 };
 
 module.exports = WarpError;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/dividedbyzeroco/warp-server#readme",
   "dependencies": {
+    "limiter": "^1.1.2",
     "async": "^2.0.0-rc.6",
     "bcryptjs": "^2.3.0",
     "body-parser": "^1.15.1",

--- a/routers/middleware.js
+++ b/routers/middleware.js
@@ -45,5 +45,17 @@ module.exports = {
     appVersion: function(req, res, next) {
         req.appVersion = req.get('X-App-Version');
         next();
+    },
+    limiter: function(throttleLimiter) {
+        return function (req, res, next) {
+            throttleLimiter.removeTokens(1, (err, remainingRequests) => {
+                if (remainingRequests < 1) {
+                    var error = new WarpError(WarpError.Code.TooManyRequest, 'Too Many Requests');
+                    next(error);
+                } else {
+                    next();
+                }
+            });
+        };
     }
 };


### PR DESCRIPTION
Example of how to use the rate limiter on created warp-server

module.exports = new WarpServer({
    security: {
        ...
    },
    database: {
        ...
    },
    models: {
        ...
    },
    migrations: {
        ...
    },
    functions: {
        ...
    },
    storage: {
        ...
    },
    queues: {
        ...
    },
    throttle: {
       limit: 5, // default throttle number is 20 if not assigned.
    }

});